### PR TITLE
refactor tests ro mocha-suit-ts

### DIFF
--- a/test/src/tests/testRunning.ts
+++ b/test/src/tests/testRunning.ts
@@ -1,107 +1,59 @@
-// 'use strict';
-//
-// import { RunSpyMethods } from '../setup';
-// import { ResetSpyMethods } from '../setup';
-// import { TestingMethods } from '../setup';
-//
-// import sinon = require("sinon");
-//
-// const MSG = "Test running.";
-//
-// describe(MSG,function(){
-//     const mod = require("mocha-suit");
-//
-//     const createSuit = function(){
-//         before(function() {
-//             this.suit = mod();
-//             this.spy = sinon.spy();
-//             this.suit.it("", this.spy);
-//         });
-//     };
-//
-//     describe("With new",function(){
-//         createSuit();
-//
-//         before(function(){
-//             new this.suit();
-//         });
-//
-//         before(RunSpyMethods);
-//
-//         it("spy should be called",function(){
-//             this.spy.called.should.be.true();
-//         });
-//
-//         after(ResetSpyMethods);
-//     });
-//
-//     describe("With simple call",function(){
-//         createSuit();
-//
-//         before(function(){
-//             this.suit();
-//         });
-//
-//         before(RunSpyMethods);
-//
-//         it("spy should be called",function(){
-//             this.spy.called.should.be.true();
-//         });
-//
-//         after(ResetSpyMethods);
-//     });
-//
-//     describe("With simple call under array of context objects",function(){
-//         const TIMES = 10;
-//
-//         createSuit();
-//
-//         before(function(){
-//             const ctxSet = [];
-//             for(let i = 0; i < TIMES; i++) {
-//                 ctxSet.push({});
-//             }
-//             this.suit(ctxSet);
-//         });
-//
-//         before(RunSpyMethods);
-//
-//         it("spy should be called",function(){
-//             this.spy.called.should.be.true();
-//             TestingMethods.it.calledTimes().should.be.eql(TIMES);
-//         });
-//
-//         after(ResetSpyMethods);
-//     });
-//
-//     describe("With simple call with testSet",function(){
-//         const TIMES = 10;
-//
-//         createSuit();
-//
-//         before(function(){
-//             const ctxSet: any = {};
-//             for(let i = 0; i < TIMES; i++) {
-//                 ctxSet[i]  = {};
-//             }
-//             ctxSet.testSet = true;
-//             this.suit(ctxSet);
-//         });
-//
-//         before(RunSpyMethods);
-//
-//         it("spy should be called",function(){
-//             this.spy.called.should.be.true();
-//
-//             try {
-//                 TestingMethods.it.calledTimes().should.be.eql(TIMES);
-//             } catch(e) {
-//                 console.log(TestingMethods.it);
-//                 throw e;
-//             }
-//
-//         });
-//
-//         after(ResetSpyMethods);
-//     });
-// });
+'use strict';
+
+import { RunSpyMethods } from '../setup';
+import { ResetSpyMethods } from '../setup';
+import { TestingMethods } from '../setup';
+
+require("should");
+const expect = require("expect.js");
+
+import {
+  Suit,
+  SuitFactory,
+  it as msIt
+  } from "mocha-suit-ts";
+
+const MSG = "Test running.";
+
+describe(MSG,function(){
+
+    @Suit()
+    class SimpleSuit {
+      @msIt("some simple check")
+      simpleCheck() {}
+    }
+
+    describe("Single test",function(){
+        before(function(){
+            new SimpleSuit();
+        });
+
+        before(RunSpyMethods);
+
+        it("'it' should be called",function(){
+          expect(TestingMethods.it.isCalled).to.be.ok();
+        });
+
+        after(ResetSpyMethods);
+    });
+
+    describe("With testSet",function(){
+        const TIMES = 10;
+
+        before(function(){
+            const ctxSet: any = {};
+            for(let i = 0; i < TIMES; i++) {
+                ctxSet["description"+i] = {};
+            }
+            SuitFactory(SimpleSuit, ctxSet);
+        });
+
+        before(RunSpyMethods);
+
+        it("'it' should be called multiple times (testSet items count)", function(){
+            TestingMethods.it.calledTimes().should.be.eql(TIMES);
+        });
+
+        after(ResetSpyMethods);
+    });
+});


### PR DESCRIPTION
"With new" - переведен под новую библиотеку 
"With simple call"  - удалено, т.к. не актуально для нового синтаксиса
"With simple call under array of context objects" -  удалено, т.к. не актуально для нового синтаксиса
"With simple call with testSet" - переведен под новую библиотеку 