### PR TITLE
Refactor mochaGeneration.ts for new syntax

### DIFF
--- a/test/src/tests/mochaGeneration.ts
+++ b/test/src/tests/mochaGeneration.ts
@@ -1,163 +1,126 @@
-// 'use strict;'
-//
-// import { RunSpyMethods } from '../setup';
-// import { ResetSpyMethods } from '../setup';
-// import { capitalize } from '../setup';
-// import { TestingMethods } from '../setup';
-//
-// import sinon = require("sinon");
-//
-// import {
-//     Suit, SuitHelper,
-//     before as msBefore,
-//     beforeEach as msBeforeEach,
-//     after as msAfter,
-//     afterEach as msAfterEach,
-//     it as msIt, that as msThat,
-//     xit as msXIt, xthat as msXThat,
-//     withHelper
-// } from "mocha-suit-ts";
-//
-//
-// describe("Check mocha methods call.",function(){
-//
-//     describe("Describe.",function(){
-//         describe("Base Suit generation.",function(){
-//             before(function(){
-//                 @Suit()
-//                 class TargetClass {}
-//
-//                 new TargetClass();
-//             });
-//
-//             before(RunSpyMethods);
-//
-//             it("One describe block should be generated.",function(){
-//                 TestingMethods.describe.calledTimes().should.be.eql(1);
-//             });
-//
-//             after(ResetSpyMethods);
-//         });
-//
-//         describe("Describe with extend.",function(){
-//             before(function(){
-//                 @Suit()
-//                 class SuperClass {}
-//
-//                 @Suit()
-//                 class TargetClass extends SuperClass {}
-//
-//                 new TargetClass();
-//             });
-//
-//             before(RunSpyMethods);
-//
-//             it("Two describe blocks should be generated.",function(){
-//                 TestingMethods.describe.calledTimes().should.be.eql(2);
-//             });
-//
-//             after(ResetSpyMethods);
-//         });
-//
-//         describe("Describe with double extend.",function(){
-//             before(function(){
-//                 @Suit()
-//                 class BaseSuperClass {}
-//
-//                 @Suit()
-//                 class SuperClass extends BaseSuperClass {}
-//
-//                 @Suit()
-//                 class TargetClass extends SuperClass {}
-//
-//                 new TargetClass();
-//             });
-//
-//             before(RunSpyMethods);
-//
-//             it("Three describe blocks should be generated.",function(){
-//                 TestingMethods.describe.calledTimes().should.be.eql(3);
-//             });
-//
-//             after(ResetSpyMethods);
-//         });
-//     });
-//
-//     const runSetup = function(d: any){
-//         describe("",function(){
-//             before(function(){
-//                 const spy = sinon.spy();
-//                 class TargetSuit {
-//                     @d.method()
-//                     call() { return spy(); }
-//                 }
-//                 this.spies = [];
-//                 for(let i = 0; i < d.times; i++) {
-//                     this.spies.push(spy);
-//                     this.suit(spy);
-//                 }
-//
-//                 this.suit();
-//             });
-//
-//             before(RunSpyMethods);
-//
-//             it(d.method + " should be called once",function(){
-//                 TestingMethods[d.method].calledTimes().should.be.eql(d.times);
-//             });
-//
-//             it(d.method + " spy should be called",function(){
-//                 for(let i = 0; i < d.times; i++) {
-//                     this.spies[i].called.should.be.true();
-//                 }
-//             });
-//
-//             after(ResetSpyMethods);
-//         });
-//     };
-//
-//     [msBefore,msBeforeEach,msAfter,msAfterEach].forEach(function(method){
-//         runSetup({ method: method, times: 10});
-//     });
-//
-//     // const runIt = function(d: any){
-//     //     describe(d.describe,function(){
-//     //         before(function(){
-//     //             this.suit = mod();
-//     //             this.spies = [];
-//     //             for(let i = 0; i < d.times; i++) {
-//     //                 const spy = sinon.spy();
-//     //                 this.spies.push(spy);
-//     //                 this.suit[d.method]("",spy);
-//     //             }
-//     //
-//     //             this.suit();
-//     //         });
-//     //
-//     //         before(RunSpyMethods);
-//     //
-//     //         it(d.toBeCalled + " should be called once",function(){
-//     //             TestingMethods[d.toBeCalled].calledTimes().should.be.eql(d.times);
-//     //         });
-//     //
-//     //         it(d.toBeCalled + " spy should be called",function(){
-//     //             for(let i = 0; i < d.times; i++) {
-//     //                 this.spies[i].called.should.be.true();
-//     //             }
-//     //         });
-//     //
-//     //         after(ResetSpyMethods);
-//     //     });
-//     // };
-//     //
-//     // [
-//     //     {method: "that", toBeCalled: "it"},
-//     //     {method: "xthat", toBeCalled: "xit"},
-//     //     {method: "it", toBeCalled: "it"},
-//     //     {method: "xit", toBeCalled: "xit"}
-//     // ].forEach(function(descr: any){
-//     //     descr.describe = capitalize(descr.method);
-//     //     descr.times = 10;
-//     //     runIt(descr);
-//     // });
-// });
+'use strict;'
+
+import { RunSpyMethods } from '../setup';
+import { ResetSpyMethods } from '../setup';
+import { TestingMethods } from '../setup';
+
+require("should");
+const expect = require("expect.js");
+import sinon = require("sinon");
+
+import {
+    Suit, SuitHelper,
+    before as msBefore,
+    beforeEach as msBeforeEach,
+    after as msAfter,
+    afterEach as msAfterEach,
+    it as msIt, that as msThat,
+    xit as msXIt, xthat as msXThat,
+    withHelper
+} from "mocha-suit-ts";
+
+
+describe("Check mocha methods call.",function(){
+
+    describe("Describe.",function(){
+        describe("Base Suit generation.",function(){
+            before(function(){
+                @Suit()
+                class TargetClass {}
+
+                new TargetClass();
+            });
+
+            before(RunSpyMethods);
+
+            it("One describe block should be generated.",function(){
+                TestingMethods.describe.calledTimes().should.be.eql(1);
+            });
+
+            after(ResetSpyMethods);
+        });
+
+        describe("Describe with extend.",function(){
+            before(function(){
+                @Suit()
+                class SuperClass {}
+
+                @Suit()
+                class TargetClass extends SuperClass {}
+
+                new TargetClass();
+            });
+
+            before(RunSpyMethods);
+
+            it("Two describe blocks should be generated.",function(){
+                TestingMethods.describe.calledTimes().should.be.eql(2);
+            });
+
+            after(ResetSpyMethods);
+        });
+
+        describe("Describe with double extend.",function(){
+            before(function(){
+                @Suit()
+                class BaseSuperClass {}
+
+                @Suit()
+                class SuperClass extends BaseSuperClass {}
+
+                @Suit()
+                class TargetClass extends SuperClass {}
+
+                new TargetClass();
+            });
+
+            before(RunSpyMethods);
+
+            it("Three describe blocks should be generated.",function(){
+                TestingMethods.describe.calledTimes().should.be.eql(3);
+            });
+
+            after(ResetSpyMethods);
+        });
+    });
+
+    const runSetup = function(method: Function, methodToBeCalled: Function){
+
+        describe(method.name + ". Define multiple times(twice).",function(){
+            const spy0 = sinon.spy();
+            const spy1 = sinon.spy();
+
+            before(function(){
+                @Suit()
+                class TargetSuit {
+                    @method()
+                    call0() { return spy0();}
+                    @method()
+                    call1() { return spy1();}
+                }
+                new TargetSuit();
+            });
+
+            before(RunSpyMethods);
+
+            it(methodToBeCalled.name + " should be called twice",function(){
+                TestingMethods[methodToBeCalled.name].calledTimes().should.be.eql(2);
+            });
+
+            it("Should be called each '"+method.name+"' definision",function(){
+                expect(spy0.called).to.be.ok();
+                expect(spy1.called).to.be.ok();
+            });
+
+            after(ResetSpyMethods);
+        });
+    };
+
+
+    [msBefore,msBeforeEach,msAfter,msAfterEach,msIt,msXIt].forEach(function(method){
+        runSetup(method, method);
+    });
+    runSetup(msThat, msIt);
+    runSetup(msXThat, msXIt);
+
+});

--- a/test/src/tests/mochaGeneration.ts
+++ b/test/src/tests/mochaGeneration.ts
@@ -9,14 +9,13 @@ const expect = require("expect.js");
 import sinon = require("sinon");
 
 import {
-    Suit, SuitHelper,
+    Suit,
     before as msBefore,
     beforeEach as msBeforeEach,
     after as msAfter,
     afterEach as msAfterEach,
     it as msIt, that as msThat,
     xit as msXIt, xthat as msXThat,
-    withHelper
 } from "mocha-suit-ts";
 
 


### PR DESCRIPTION
В тесте, где проверяется вызов нескольких однотипных методов, сделала упрощение: в исходном варианте генерировалось произвольное число однотипных методов (10). Не знаю как автоматически сгенерировать произвольное количество декораторов при определении класса, поэтому ограничилась двумя экземплярами прописанными вручную, считаю это адекватной заменой для тестирования нескольких экземпляров одноименных методов-декораторов